### PR TITLE
Added option to use iterator element keys

### DIFF
--- a/src/Monga/Cursor.php
+++ b/src/Monga/Cursor.php
@@ -81,11 +81,12 @@ class Cursor implements \Countable, \IteratorAggregate
 	/**
 	 * Returns the result as an array
 	 *
-	 * @return  array  the iterator as array
+	 * @param   string  $method     method name
+	 * @return  boolean	$useKeys	use the iterator element keys as index
 	 */
-	public function toArray()
+	public function toArray($useKeys = false)
 	{
-		return iterator_to_array($this->getIterator());
+		return iterator_to_array($this->getIterator(), $useKeys);
 	}
 
 	/**


### PR DESCRIPTION
Added option to Monga::Cursor::toArray method to use the itereator
element keys as index or not
